### PR TITLE
Created the "uwp" tag

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,22 @@
+# Auto detect text files and perform LF normalization
+* text=auto
+
+# Custom for Visual Studio
+*.cs     diff=csharp
+*.sln    merge=union
+*.csproj merge=union
+*.vbproj merge=union
+*.fsproj merge=union
+*.dbproj merge=union
+
+# Standard to msysgit
+*.doc	 diff=astextplain
+*.DOC	 diff=astextplain
+*.docx diff=astextplain
+*.DOCX diff=astextplain
+*.dot  diff=astextplain
+*.DOT  diff=astextplain
+*.pdf  diff=astextplain
+*.PDF	 diff=astextplain
+*.rtf	 diff=astextplain
+*.RTF	 diff=astextplain

--- a/result.csv
+++ b/result.csv
@@ -46,3 +46,4 @@ microsoftdynamics,Microsoft Dynamics,Tools for managing your business and custom
 microsoftopentechnologies,Microsoft Open Technologies,Open source utilities from Microsoft
 microsoftresearch,Microsoft Research,Research based code
 windowsphone,Windows Phone,Microsoft's mobile offering
+uwp,UWP,The Universal Windows Platform is a common software platform for all devices running Windows 10

--- a/tags/uwp.md
+++ b/tags/uwp.md
@@ -1,0 +1,6 @@
+---
+name: uwp
+displayName: UWP
+description: The Universal Windows Platform is a common software platform for all devices running Windows 10
+---
+The Universal Windows Platform is a common software platform for all devices running Windows 10


### PR DESCRIPTION
I've added the "uwp" tag for the Universal Windows Platform used in Windows 10.

I've also added a default `.gitatributes` file that ensures proper handling of <kbd>LF</kbd>.