### PR TITLE
Added vscode tag info

### DIFF
--- a/tags/vscode.md
+++ b/tags/vscode.md
@@ -1,0 +1,6 @@
+---
+name: vscode
+displayName: Visual Studio Code (VS Code)
+description: VS Code is a new type of tool that combines the simplicity of a code editor with what developers need for their core edit-build-debug cycle.
+---
+Visual Studio Code (VS Code) is a free, open-source, source code editor developed by Microsoft for Windows, Linux and macOS. It includes support for debugging, embedded Git control, syntax highlighting, intelligent code completion, snippets, and code refactoring. It is also customizable, so users can change the editor's theme, keyboard shortcuts, and preferences.


### PR DESCRIPTION
Found this whilst looking for improvements to MS repos as part of Hacktoberfest, as I noticed that lots of the tags on [https://opensource.microsoft.com](https://opensource.microsoft.com) don't display additional information under the Info tab and prompt contributions.

Added VS Code as a starter to check approach/tone/usefulness, but very happy to complete others if it's going to be worthwhile. 