### PR TITLE
Adding more tags

### DIFF
--- a/tags/api.md
+++ b/tags/api.md
@@ -1,0 +1,7 @@
+---
+name: api
+displayName: API
+description: Application Programming Interface
+---
+
+An Application Programming Interface describes a set of endpoints and functions that other programs can interact with.

--- a/tags/assembly.md
+++ b/tags/assembly.md
@@ -1,0 +1,7 @@
+---
+name: assembly
+displayName: Assembly
+description: A low-level programming language
+---
+
+An assembly (or assembler) language, is any low-level programming language.

--- a/tags/directx.md
+++ b/tags/directx.md
@@ -1,0 +1,7 @@
+---
+name: directx
+displayName: DirectX
+description: Collection of multimedia APIs
+---
+
+DirectX is a collection of APIs for multimedia, game programming and video, developed by Microsoft.

--- a/tags/ios.md
+++ b/tags/ios.md
@@ -1,0 +1,6 @@
+---
+name: ios
+displayName: iOS
+description: Mobile operating system
+---
+iOS is a mobile operating system developed by Apple.

--- a/tags/python.md
+++ b/tags/python.md
@@ -1,0 +1,7 @@
+---
+name: python
+displayName: Python
+description: Popular programming language
+---
+
+Python is a popular programming language that is reliable, flexible, easy to learn, free to use on all operating systems, and supported by both a strong developer community and many free libraries.

--- a/tags/vscode.md
+++ b/tags/vscode.md
@@ -1,0 +1,7 @@
+---
+name: vscode
+displayName: VS Code
+description: Open source code editor
+---
+
+VS Code is an open source code editor developed by Microsoft.


### PR DESCRIPTION
Adding tags for Assembly, API, Python, VS Code, DirectX and iOS.
Mostly just to get the capitalisation right on opensource.microsoft.com.

I also found other tags that should probably be given the same treatment, but I didn't know enough to write correct description. Should I open an issue with those?

```
rust
inno
jupyter notebook
automatic
ruby
vsts
officedev
docs
ci
xamarin
xamarin-docs
```