### PR TITLE
Fix generate.js crashing on node 10

### DIFF
--- a/generate.js
+++ b/generate.js
@@ -11,5 +11,9 @@ fs.createReadStream(filename)
   .pipe(csv())
   .on('data', function (data) {
     const markdown = `---\nname: ${data.name}\ndisplayName: ${data.displayName}\ndescription: ${data.description}\n---\n${data.content || data.description}`;
-    fs.writeFile(`tags/${data.name}.md`, markdown);
+    fs.writeFile(`tags/${data.name}.md`, markdown, (err) => {
+      if(err){
+        console.log(`Could not save file ${data.name}.md: `, err);
+      }
+    });
   });


### PR DESCRIPTION
The writeFile method was called without callback, which prints [this](https://nodejs.org/api/deprecations.html#deprecations_dep0013_fs_asynchronous_function_without_callback) deprecation warning when on node < 10 and throws TypeError when on node 10.